### PR TITLE
added renderHours function

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -8,7 +8,70 @@ $(function () {
   // function? How can DOM traversal be used to get the "hour-x" id of the
   // time-block containing the button that was clicked? How might the id be
   // useful when saving the description in local storage?
+
+  
+function renderHours() {
+  var hours = [
+    '9AM',
+    '10AM',
+    '11AM',
+    '12PM',
+    '1PM',
+    '2PM',
+    '3PM',
+    '4PM',
+    '5PM',
+  ];
+
+  for (var i = 0; i < hours.length; i++) {
+    //create time-block row div
+    var timeBlock = $ ('<div>');
+    //create div for hour text
+    var hourDisplay = $('<div>');
+    //create variable for text area
+    var textAreaEl = $('<textarea>');
+    //create variable to make button 
+    var buttonEl = $('<button>');
+
+    //assign style to time block with classes from example
+    timeBlock.addClass('row time-block');
+    //create id for time block div
+    timeBlock.attr('id', 'hour-' + hours[i]);
+
+    //attach div for hour label
+    timeBlock.append(hourDisplay);
+    //assign style to div child of timeBlock aka hourDisplay
+    hourDisplay.addClass('col-2 col-md-1 hour text-center py-3');
+    //add hour text to div
+    hourDisplay.text(hours[i]);
+    //add text area as child of timeBlock
+    timeBlock.append(textAreaEl);
+    //add class to textareaEl
+    textAreaEl.addClass('col-8 col-md-10 description', 'rows="3"');
+    //add button as child of timeBlock div
+    timeBlock.append(buttonEl);
+    //add class to button
+    buttonEl.addClass('btn saveBtn col-2 col-md-1');
+    //in this place I need to add the <i> child for the button, also need aria label, can that go in the same line as the class? can rows=3 go in the same line as the class on text area?
+    //append timeBlock to the document body
+    $('body').append(timeBlock);
+  };
+}
+renderHours(); //calls the renderHours function to execute the code
+    //
+    // Create button
+    //var letterBtn = $('<button>');
+    // Assign style to the button
+    //letterBtn.addClass('letter-button btn btn-info');
+    // Assign the letter to the data-letter attribute
+    //letterBtn.attr('data-letter', letters[i]);
+    // Display the letter
+    //letterBtn.text(letters[i]);
+    // Attach the letter element
+    //buttonListEl.append(letterBtn);
+
   //
+  /* commented out 14-27, need to replace vanilla javascript with jquery
   var saveButton = document.querySelector(".btn.saveBtn.col-2.col-md-1"); //creates variable targeting the save buttons
   var hourNineText = document.querySelector(".col-8.col-md-10.description"); //selects the hour-9 id div 
 
@@ -21,7 +84,7 @@ $(function () {
 
     localStorage.setItem("input", JSON.stringify(input));
     console.log(input); //saves input of 'input' variable as a string in local storage
-  }); 
+  }); */
 
   // TODO: Add code to apply the past, present, or future class to each time
   // block by comparing the id to the current hour. HINTS: How can the id

--- a/index.html
+++ b/index.html
@@ -38,7 +38,9 @@
       <p class="lead">A simple calendar app for scheduling your work day</p>
       <p id="currentDay" class="lead"></p>
     </header>
-    <div class="container-fluid px-5">
+    <div id="time-row-parent" class="container-fluid px-5">
+
+    </div>
       <!-- Use class for "past", "present", and "future" to apply styles to the
         time-block divs accordingly. The javascript will need to do this by
         adding/removing these classes on each div by comparing the hour in the
@@ -50,66 +52,66 @@
         -->
 
       <!-- Example of a past time block. The "past" class adds a gray background color. -->
-      <div id="hour-9" class="row time-block past">
+      <!--<div id="hour-9" class="row time-block past">
         <div class="col-2 col-md-1 hour text-center py-3">9AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
       <!-- Example of a present time block. The "present" class adds a red background color. -->
-      <div id="hour-10" class="row time-block present">
+      <!--<div id="hour-10" class="row time-block present">
         <div class="col-2 col-md-1 hour text-center py-3">10AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
       <!-- Example of a future time block. The "future" class adds a green background color. -->
-      <div id="hour-11" class="row time-block future">
+      <!--<div id="hour-11" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">11AM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
       <!--Adding hours 12-5pm -VG -->
-      <div id="hour-12" class="row time-block future">
+      <!--<div id="hour-12" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">12PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
-      <div id="hour-1" class="row time-block future">
+      <!--<div id="hour-1" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">1PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
-      <div id="hour-2" class="row time-block future">
+      <!-- <div id="hour-2" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">2PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
-      <div id="hour-3" class="row time-block future">
+      <!-- <div id="hour-3" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">3PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
-      </div>
+      </div> -->
 
-      <div id="hour-4" class="row time-block future">
+      <!--<div id="hour-4" class="row time-block future">
         <div class="col-2 col-md-1 hour text-center py-3">4PM</div>
         <textarea class="col-8 col-md-10 description" rows="3"> </textarea>
         <button class="btn saveBtn col-2 col-md-1" aria-label="save">
@@ -124,7 +126,7 @@
           <i class="fas fa-save" aria-hidden="true"></i>
         </button>
       </div>
-    </div>
+    </div> -->
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dayjs@1.11.3/dayjs.min.js"


### PR DESCRIPTION
replaced vanilla javascript and html used in error with jquery by doing the following:

-commented out example html elements and styling in html document, added an id to the div that precedes the example code at line 41 html so that it can be identified as the parent container for the dynamically inserted html made by JS

Removed the vanilla javascript I had started writing on the previous commit, replaced with the renderHours function to dynamically inject the divs for text areas, save buttons, and hour labels. appended classes to these elements to style them per the example code styling. 

-still incomplete as of this commit: need to update function to finish styling the save buttons